### PR TITLE
Improve BLE connection reliability

### DIFF
--- a/gui/gui1_pyside.py
+++ b/gui/gui1_pyside.py
@@ -148,7 +148,7 @@ class GUI1_Widget(QWidget):
         self.update_button_states()
 
         self.main_app.async_helper.run_async_task(
-            self.main_app.ble.connect(address),
+            self.main_app.ble.connect_with_retry(address),
             self.main_app.connect_results_signal,
             self.main_app.connect_error_signal
         )

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ async def attempt_auto_connect(app_instance):
         # Csatlakozási kísérlet indítása az AsyncHelper segítségével
         # Az eredményt a done_callback fogja kezelni és a signalokat kibocsátani
         future = app_instance.async_helper.run_async_task(
-            app_instance.ble.connect(last_addr),
+            app_instance.ble.connect_with_retry(last_addr),
             app_instance.connect_results_signal,
             app_instance.connect_error_signal
         )


### PR DESCRIPTION
## Summary
- implement `connect_with_retry` to repeatedly try connecting to the LED
- use the retry logic for manual and automatic connections

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456bb2a5c483278c3a2c41ceeb8026