### PR TITLE
Fix profile dropdown init

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,8 @@ BASE_DIR.mkdir(parents=True, exist_ok=True)
 
 # Az ütemezés fájl teljes elérési útja
 CONFIG_FILE = str(BASE_DIR / "led_schedule.json")
+# Új fájl az ütemezési profilok tárolásához
+PROFILES_FILE = str(BASE_DIR / "led_schedule_profiles.json")
 
 CHARACTERISTIC_UUID = "0000fff3-0000-1000-8000-00805f9b34fb"
 

--- a/gui/main_window_base.py
+++ b/gui/main_window_base.py
@@ -105,9 +105,12 @@ class LEDApp_BaseWindow(QMainWindow):
         self.sunset = None
         self.connection_status = "disconnected"
         self._current_gui_widget = None # Ezt a GuiManager is látja/módosítja
-        self.schedule = {day: {"color": "", "on_time": "", "off_time": "",
-                               "sunrise": False, "sunrise_offset": 0,
-                               "sunset": False, "sunset_offset": 0} for day in DAYS}
+        default_schedule = {day: {"color": "", "on_time": "", "off_time": "",
+                                 "sunrise": False, "sunrise_offset": 0,
+                                 "sunset": False, "sunset_offset": 0} for day in DAYS}
+        self.profiles = {"Alap": {"active": True, "schedule": default_schedule}}
+        self.current_profile_name = "Alap"
+        self.schedule = default_schedule
         self.ble = BLEController()
         self._is_auto_starting = False # Új flag az automatikus indulás jelzésére
         self._initial_connection_attempted = False # Új flag


### PR DESCRIPTION
### **User description**
## Summary
- fix initialization order for schedule profiles dropdown
- track current profile name in main app state

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68457de622b08327ad96a444f2656026


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce schedule profile management with dropdown menu
  - Add support for multiple named schedule profiles
  - Enable switching, activating, and creating profiles via GUI
  - Persist profiles in a new JSON file

- Refactor schedule loading, saving, and checking logic for profiles
  - Replace single schedule logic with profile-based logic
  - Update timers and GUI to use profile-aware functions

- Track current profile name in main app state

- Update GUI to support profile selection and activation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add constant for schedule profiles JSON file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config.py

<li>Add <code>PROFILES_FILE</code> constant for new profiles JSON file.<br> <li> No changes to existing config values.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/5/files#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gui2_schedule_logic.py</strong><dd><code>Refactor schedule logic for profile support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/gui2_schedule_logic.py

<li>Refactor schedule logic to support multiple profiles.<br> <li> Add functions to load, save, and check profiles.<br> <li> Replace single schedule logic with profile-based logic.<br> <li> Add backward compatibility for old single schedule files.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/5/files#diff-0faed963482c813c6b3b766f9ca2e77b3194ac6660b8759d25fb6ed61d6cd565">+185/-164</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gui2_schedule_pyside.py</strong><dd><code>Add GUI controls for schedule profiles management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/gui2_schedule_pyside.py

<li>Add dropdown menu and controls for schedule profiles.<br> <li> Integrate profile selection, activation, and creation in GUI.<br> <li> Update timers and slots to use profile-aware logic.<br> <li> Refactor schedule table to work with selected profile.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/5/files#diff-8c19744d33697fd41aef4fe0560d3e59c256c288450f90eb9531cf2a98f46040">+103/-28</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window_base.py</strong><dd><code>Track profiles and current profile in main app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window_base.py

<li>Add <code>profiles</code> and <code>current_profile_name</code> to main app state.<br> <li> Initialize default profile and schedule.<br> <li> Update schedule initialization for profile support.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/5/files#diff-f899423080712b0e03d31b7aca1075c5e01dd26267c4efecd73d172d7471a594">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>