### PR TITLE
Fix profile dropdown init

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,8 @@ BASE_DIR.mkdir(parents=True, exist_ok=True)
 
 # Az ütemezés fájl teljes elérési útja
 CONFIG_FILE = str(BASE_DIR / "led_schedule.json")
+# Új fájl az ütemezési profilok tárolásához
+PROFILES_FILE = str(BASE_DIR / "led_schedule_profiles.json")
 
 CHARACTERISTIC_UUID = "0000fff3-0000-1000-8000-00805f9b34fb"
 

--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import Qt
 
 # Importáljuk a szükséges konfigurációs és backend/core elemeket
-from config import COLORS, DAYS, CONFIG_FILE
+from config import COLORS, DAYS, CONFIG_FILE, PROFILES_FILE
 from core.sun_logic import get_local_sun_info, get_hungarian_day_name, DAYS_HU
 from core.location_utils import get_sun_times # Bár itt nincs közvetlen hívás, a main_app tartalmazza
 
@@ -35,51 +35,97 @@ except Exception as e:
 
 # --- Logika Függvények ---
 
-def load_schedule_from_file(main_app):
-    """
-    Betölti az ütemezést a JSON fájlból a main_app.schedule-be.
-    Args:
-        main_app: A fő alkalmazás példánya (LEDApp_PySide).
-    """
-    default_schedule = {day: {"color": COLORS[0][0] if COLORS else "", "on_time": "", "off_time": "", "sunrise": False, "sunrise_offset": 0, "sunset": False, "sunset_offset": 0} for day in DAYS}
+def get_default_schedule():
+    """Alapértelmezett ütemezés létrehozása."""
+    return {
+        day: {
+            "color": COLORS[0][0] if COLORS else "",
+            "on_time": "",
+            "off_time": "",
+            "sunrise": False,
+            "sunrise_offset": 0,
+            "sunset": False,
+            "sunset_offset": 0,
+        }
+        for day in DAYS
+    }
+
+
+def load_profiles_from_file(main_app):
+    """Betölti az ütemezési profilokat."""
+    default_schedule = get_default_schedule()
+    default_profiles = {"Alapértelmezett": {"active": True, "schedule": default_schedule}}
+
+    if os.path.exists(PROFILES_FILE):
+        try:
+            with open(PROFILES_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+
+            profiles = {}
+            for name, prof in data.items():
+                active = bool(prof.get("active", True))
+                sched = prof.get("schedule", {})
+                merged = {}
+                for day in DAYS:
+                    d = default_schedule[day].copy()
+                    if day in sched and isinstance(sched[day], dict):
+                        for key in d:
+                            if key in sched[day]:
+                                val = sched[day][key]
+                                if key.endswith("_offset"):
+                                    try:
+                                        d[key] = int(val)
+                                    except (ValueError, TypeError):
+                                        d[key] = 0
+                                elif isinstance(val, type(d[key])):
+                                    d[key] = val
+                    merged[day] = d
+                profiles[name] = {"active": active, "schedule": merged}
+
+            if profiles:
+                main_app.profiles = profiles
+                return
+        except Exception as e:
+            print(f"Hiba a profilok betöltésekor: {e}")
+    # Visszafelé kompatibilitás: régi egyprofilos fájl
+    single_schedule = default_schedule.copy()
     if os.path.exists(CONFIG_FILE):
         try:
-            with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
-                loaded_data = json.load(f)
-            merged_schedule = {}
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
             for day in DAYS:
-                 day_data = default_schedule[day].copy()
-                 if day in loaded_data and isinstance(loaded_data[day], dict):
-                      for key in day_data:
-                           if key in loaded_data[day]:
-                                expected_type = type(day_data[key])
-                                loaded_val = loaded_data[day][key]
-                                # Speciális kezelés offset-re (mindig int legyen)
-                                if key.endswith("_offset"):
-                                     try:
-                                         day_data[key] = int(loaded_val)
-                                     except (ValueError, TypeError):
-                                         print(f"Figyelmeztetés: Érvénytelen offset érték ('{loaded_val}') a '{day}' nap '{key}' kulcsánál. 0 lesz használva.")
-                                         day_data[key] = 0 # Alapértelmezett offset hiba esetén
-                                elif isinstance(loaded_val, expected_type):
-                                     day_data[key] = loaded_val
-                                else:
-                                    print(f"Figyelmeztetés: Típuseltérés a '{day}' nap '{key}' kulcsánál. Mentett: {type(loaded_val)}, Várt: {expected_type}. Alapértelmezett használata.")
-                 merged_schedule[day] = day_data
-            main_app.schedule = merged_schedule
-
-        except json.JSONDecodeError:
-            print(f"Hiba: A {CONFIG_FILE} fájl hibás JSON formátumú. Alapértelmezett ütemezés használata.")
-            main_app.schedule = default_schedule.copy()
+                d = single_schedule[day].copy()
+                if day in loaded and isinstance(loaded[day], dict):
+                    for key in d:
+                        if key in loaded[day]:
+                            val = loaded[day][key]
+                            if key.endswith("_offset"):
+                                try:
+                                    d[key] = int(val)
+                                except (ValueError, TypeError):
+                                    d[key] = 0
+                            elif isinstance(val, type(d[key])):
+                                d[key] = val
+                single_schedule[day] = d
         except Exception as e:
-            print(f"Hiba a schedule betöltésekor: {e}. Alapértelmezett ütemezés használata.")
-            main_app.schedule = default_schedule.copy()
-    else:
-         print(f"Nincs mentett schedule ({CONFIG_FILE}), alapértelmezett ütemezés használata.")
-         main_app.schedule = default_schedule.copy()
+            print(f"Hiba a régi ütemezés betöltésekor: {e}")
+
+    default_profiles["Alapértelmezett"]["schedule"] = single_schedule
+    main_app.profiles = default_profiles
 
 
-def save_schedule(gui_widget):
+def _save_profiles_to_file(main_app):
+    """Segédfüggvény a profilok mentéséhez."""
+    try:
+        with open(PROFILES_FILE, "w", encoding="utf-8") as f:
+            json.dump(main_app.profiles, f, ensure_ascii=False, indent=4)
+        return True
+    except Exception as e:
+        print(f"Hiba a profilok mentésekor: {e}")
+        return False
+
+
+def save_profile(gui_widget):
     """
     Elmenti az aktuális ütemezési beállításokat JSON fájlba a GUI widgetek alapján.
     Args:
@@ -138,118 +184,93 @@ def save_schedule(gui_widget):
         return
 
     try:
-        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
-            json.dump(schedule_to_save, f, ensure_ascii=False, indent=4)
-        QMessageBox.information(gui_widget, "Mentés sikeres", "Az ütemezés sikeresen elmentve.")
-        # Frissítjük az app belső állapotát is a mentett adatokkal
-        gui_widget.main_app.schedule = schedule_to_save
-        # Újra ellenőrizzük az ütemezést a friss adatokkal
-        check_schedule(gui_widget)
+        profile_name = getattr(gui_widget, "current_profile_name", None)
+        if not profile_name:
+            QMessageBox.critical(gui_widget, "Hiba", "Nincs kiválasztott profil a mentéshez.")
+            return
+
+        gui_widget.main_app.profiles[profile_name]["schedule"] = schedule_to_save
+        if _save_profiles_to_file(gui_widget.main_app):
+            QMessageBox.information(gui_widget, "Mentés sikeres", "Az ütemezés sikeresen elmentve.")
+            gui_widget.main_app.schedule = schedule_to_save
+        else:
+            QMessageBox.critical(gui_widget, "Mentési hiba", "Nem sikerült a profilok mentése.")
     except Exception as e:
-        QMessageBox.critical(gui_widget, "Mentési hiba", f"Hiba történt a fájl írása során: {e}")
+        QMessageBox.critical(gui_widget, "Mentési hiba", f"Hiba történt a mentés során: {e}")
 
 
-def check_schedule(gui_widget):
-    """
-    Ellenőrzi az ütemezést és szükség esetén parancsot küld a LED-nek.
-    Args:
-        gui_widget: A GUI2_Widget példánya.
-    """
+
+def check_profiles(gui_widget):
+    """Aktív ütemezési profilok ellenőrzése és LED vezérlése."""
     now_local = datetime.now(LOCAL_TZ)
     today_name_hu = DAYS_HU.get(now_local.strftime('%A'), now_local.strftime('%A'))
 
-    if today_name_hu not in gui_widget.schedule_widgets:
-        return
-
-    day_data_widgets = gui_widget.schedule_widgets[today_name_hu]
-    main_app = gui_widget.main_app # Rövidítés
+    main_app = gui_widget.main_app
+    desired_hex = None
 
     try:
-        on_time_dt = None
-        off_time_dt = None
+        for name, prof in main_app.profiles.items():
+            if not prof.get("active", False):
+                continue
 
-        # --- Bekapcsolási idő meghatározása ---
-        if day_data_widgets["sunrise"].isChecked():
-            offset_str = day_data_widgets["sunrise_offset"].text()
-            try:
-                offset = int(offset_str if offset_str else 0)
-                if main_app.sunrise: # Ellenőrizzük, hogy van-e érvényes napkelte adat
-                    # Fontos: A main_app.sunrise már a helyi időzónában van
-                    on_time_dt = main_app.sunrise + timedelta(minutes=offset)
-            except (ValueError, TypeError) as e:
-                print(f"Hiba a napkelte offset feldolgozásakor ({today_name_hu}): {e}")
-                pass # Hiba esetén None marad
+            day_data = prof.get("schedule", {}).get(today_name_hu)
+            if not day_data:
+                continue
 
-        else: # Fix időpont használata
-            on_time_str = day_data_widgets["on_time"].currentText()
-            if on_time_str:
+            on_time_dt = None
+            off_time_dt = None
+
+            if day_data.get("sunrise"):
                 try:
-                    time_obj = dt_time.fromisoformat(on_time_str)
-                    naive_dt = datetime.combine(now_local.date(), time_obj)
-                    on_time_dt = LOCAL_TZ.localize(naive_dt)
-                except ValueError as e:
-                    print(f"Hiba a bekapcsolási idő ('{on_time_str}') feldolgozásakor ({today_name_hu}): {e}")
-                    pass # Hiba esetén None marad
+                    offset = int(day_data.get("sunrise_offset", 0))
+                    if main_app.sunrise:
+                        on_time_dt = main_app.sunrise + timedelta(minutes=offset)
+                except (ValueError, TypeError):
+                    pass
+            else:
+                on_str = day_data.get("on_time")
+                if on_str:
+                    try:
+                        time_obj = dt_time.fromisoformat(on_str)
+                        on_time_dt = LOCAL_TZ.localize(datetime.combine(now_local.date(), time_obj))
+                    except ValueError:
+                        pass
 
-        # --- Kikapcsolási idő meghatározása ---
-        if day_data_widgets["sunset"].isChecked():
-             offset_str = day_data_widgets["sunset_offset"].text()
-             try:
-                 offset = int(offset_str if offset_str else 0)
-                 if main_app.sunset: # Ellenőrizzük, hogy van-e érvényes napnyugta adat
-                     # Fontos: A main_app.sunset már a helyi időzónában van
-                     off_time_dt = main_app.sunset + timedelta(minutes=offset)
-             except (ValueError, TypeError) as e:
-                 print(f"Hiba a napnyugta offset feldolgozásakor ({today_name_hu}): {e}")
-                 pass
-        else: # Fix időpont használata
-             off_time_str = day_data_widgets["off_time"].currentText()
-             if off_time_str:
-                 try:
-                     time_obj = dt_time.fromisoformat(off_time_str)
-                     naive_dt = datetime.combine(now_local.date(), time_obj)
-                     off_time_dt = LOCAL_TZ.localize(naive_dt)
-                     # Éjfél átnyúlás kezelése: ha a kikapcsolás korábbi, mint a bekapcsolás,
-                     # akkor a kikapcsolás másnapra vonatkozik
-                     if on_time_dt and off_time_dt <= on_time_dt:
-                         print(f"SCHEDULE: Éjfél átnyúlás észlelve ({today_name_hu}), kikapcsolás másnapra tolva.")
-                         off_time_dt += timedelta(days=1)
-                 except ValueError as e:
-                     print(f"Hiba a kikapcsolási idő ('{off_time_str}') feldolgozásakor ({today_name_hu}): {e}")
-                     pass
+            if day_data.get("sunset"):
+                try:
+                    offset = int(day_data.get("sunset_offset", 0))
+                    if main_app.sunset:
+                        off_time_dt = main_app.sunset + timedelta(minutes=offset)
+                except (ValueError, TypeError):
+                    pass
+            else:
+                off_str = day_data.get("off_time")
+                if off_str:
+                    try:
+                        time_obj = dt_time.fromisoformat(off_str)
+                        off_time_dt = LOCAL_TZ.localize(datetime.combine(now_local.date(), time_obj))
+                        if on_time_dt and off_time_dt <= on_time_dt:
+                            off_time_dt += timedelta(days=1)
+                    except ValueError:
+                        pass
 
-        # --- Művelet végrehajtása ---
-        if on_time_dt and off_time_dt:
-            target_color_name = day_data_widgets["color"].currentText()
-            target_color_hex = next((c[2] for c in COLORS if c[0] == target_color_name), None)
+            if on_time_dt and off_time_dt:
+                target_color_name = day_data.get("color", "")
+                target_color_hex = next((c[2] for c in COLORS if c[0] == target_color_name), None)
+                if not target_color_hex:
+                    continue
+                if on_time_dt <= now_local < off_time_dt:
+                    desired_hex = target_color_hex
+                    break
 
-            if not target_color_hex:
-                print(f"SCHEDULE: Nincs érvényes HEX kód a '{target_color_name}' színhez ({today_name_hu}).")
-                return # Ha nincs szín, ne csináljunk semmit
-
-            # Ellenőrzés, hogy az aktuális idő a be/ki intervallumban van-e
-            # Megengedőbb ellenőrzés: now >= on és now < off
-            should_be_on = on_time_dt <= now_local < off_time_dt
-
-            # Debug log
-            # print(f"DEBUG ({today_name_hu}): Now={now_local.strftime('%H:%M:%S')}, On={on_time_dt.strftime('%H:%M:%S')}, Off={off_time_dt.strftime('%H:%M:%S')}, ShouldBeOn={should_be_on}, IsLEDOn={main_app.is_led_on}, LastColor={main_app.last_color_hex}, TargetColor={target_color_hex}")
-
-            # Csak akkor küld parancsot, ha az állapot változna
-            if should_be_on and (not main_app.is_led_on or main_app.last_color_hex != target_color_hex):
-                print(f"SCHEDULE: Bekapcsolás/színváltás ({target_color_name}) - Idő: {now_local.strftime('%H:%M')}")
-                # Közvetlenül hívjuk a controls widget metódusát
+        if desired_hex:
+            if not main_app.is_led_on or main_app.last_color_hex != desired_hex:
                 if gui_widget.controls_widget:
-                    gui_widget.controls_widget.send_color_command(target_color_hex)
-            elif not should_be_on and main_app.is_led_on:
-                print(f"SCHEDULE: Kikapcsolás - Idő: {now_local.strftime('%H:%M')}")
-                # Közvetlenül hívjuk a controls widget metódusát
-                if gui_widget.controls_widget:
-                    gui_widget.controls_widget.turn_off_led()
-
-        # else: # Debug: Ha valamelyik időpont hiányzik
-        #     print(f"DEBUG ({today_name_hu}): Hiányzó időpont(ok): On={on_time_dt}, Off={off_time_dt}")
-
+                    gui_widget.controls_widget.send_color_command(desired_hex)
+        else:
+            if main_app.is_led_on and gui_widget.controls_widget:
+                gui_widget.controls_widget.turn_off_led()
 
     except Exception as e:
-         print(f"Váratlan hiba a schedule ellenőrzésekor ({today_name_hu}): {e}")
-         traceback.print_exc()
+        print(f"Váratlan hiba a profilok ellenőrzésekor: {e}")
+        traceback.print_exc()

--- a/gui/main_window_base.py
+++ b/gui/main_window_base.py
@@ -105,9 +105,12 @@ class LEDApp_BaseWindow(QMainWindow):
         self.sunset = None
         self.connection_status = "disconnected"
         self._current_gui_widget = None # Ezt a GuiManager is látja/módosítja
-        self.schedule = {day: {"color": "", "on_time": "", "off_time": "",
-                               "sunrise": False, "sunrise_offset": 0,
-                               "sunset": False, "sunset_offset": 0} for day in DAYS}
+        default_schedule = {day: {"color": "", "on_time": "", "off_time": "",
+                                 "sunrise": False, "sunrise_offset": 0,
+                                 "sunset": False, "sunset_offset": 0} for day in DAYS}
+        self.profiles = {"Alap": {"active": True, "schedule": default_schedule}}
+        self.current_profile_name = "Alap"
+        self.schedule = default_schedule
         self.ble = BLEController()
         self._is_auto_starting = False # Új flag az automatikus indulás jelzésére
         self._initial_connection_attempted = False # Új flag


### PR DESCRIPTION
### **User description**
## Summary
- fix initialization order for schedule profiles dropdown
- track current profile name in main app state
- refine default profile loading logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68457de622b08327ad96a444f2656026


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce scheduler profiles with dropdown selection in the GUI
  - Add support for multiple named schedule profiles
  - Allow activating/deactivating profiles and switching via dropdown
  - Add logic to load, save, and manage profiles in a dedicated JSON file

- Refactor schedule logic to support profile-based scheduling
  - Replace single schedule file with profiles file
  - Update schedule checking and saving to operate per profile

- Update main app state to track current profile and profiles

- Enhance GUI to support profile creation, activation, and switching


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add profiles file path for schedule profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config.py

<li>Add <code>PROFILES_FILE</code> constant for storing schedule profiles<br> <li> No changes to existing config values


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/6/files#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gui2_schedule_logic.py</strong><dd><code>Refactor schedule logic to support profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/gui2_schedule_logic.py

<li>Add logic for loading, saving, and merging multiple schedule profiles<br> <li> Replace single schedule logic with profile-based logic<br> <li> Implement functions for profile management and backward compatibility<br> <li> Add logic to check and control LEDs based on active profiles


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/6/files#diff-0faed963482c813c6b3b766f9ca2e77b3194ac6660b8759d25fb6ed61d6cd565">+185/-164</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gui2_schedule_pyside.py</strong><dd><code>Add GUI dropdown and controls for scheduler profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/gui2_schedule_pyside.py

<li>Add dropdown menu and controls for selecting and managing profiles<br> <li> Integrate profile switching, activation, and creation in GUI<br> <li> Update save/reset/check logic to operate per profile<br> <li> Connect GUI actions to new profile logic functions


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/6/files#diff-8c19744d33697fd41aef4fe0560d3e59c256c288450f90eb9531cf2a98f46040">+103/-28</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window_base.py</strong><dd><code>Track profiles and current profile in main app state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window_base.py

<li>Add <code>profiles</code> and <code>current_profile_name</code> to main app state<br> <li> Initialize default profile and schedule in app state


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/LEDapp17/pull/6/files#diff-f899423080712b0e03d31b7aca1075c5e01dd26267c4efecd73d172d7471a594">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>