### PR TITLE
Add visible schedule profile selector

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -126,19 +126,29 @@ class GUI2_Widget(QWidget):
         # --- Felső sáv vége ---
         main_layout.addLayout(top_bar_layout)
         # main_layout.addSpacing(120) # Korábbi nagy térköz visszaállítása
-        main_layout.addStretch(1) # Rugalmas térköz a felső és középső rész között
+        # Kisebb távolság a felső sáv és a vezérlők között, hogy a profilválasztó
+        # látható maradjon kisebb képernyőn is
+        main_layout.addSpacing(10)
 
         # --- Vezérlő Widget ---
         self.controls_widget = GUI2_ControlsWidget(self.main_app)
         main_layout.addWidget(self.controls_widget, 0, Qt.AlignmentFlag.AlignCenter)
-        # main_layout.addSpacing(70) # Korábbi nagy térköz visszaállítása
-        main_layout.addStretch(1) # Rugalmas térköz a vezérlők és az ütemező között
+        main_layout.addSpacing(10)
+
+        # Betöltjük az ütemezési profilokat még a profilválasztó létrehozása előtt
+        logic.load_profiles_from_file(self.main_app)
+        if not hasattr(self.main_app, 'profiles') or not self.main_app.profiles:
+            self.main_app.profiles = {"Alap": {"active": True, "schedule": logic.get_default_schedule()}}
+
+        self.current_profile_name = list(self.main_app.profiles.keys())[0]
+        self.main_app.schedule = self.main_app.profiles[self.current_profile_name]["schedule"]
 
         # --- Profilválasztó ---
         profile_layout = QHBoxLayout()
         profile_label = QLabel("Profil:")
         self.profile_combo = QComboBox()
         self.profile_combo.addItems(self.main_app.profiles.keys())
+        self.profile_combo.setCurrentText(self.current_profile_name)
         self.profile_combo.currentTextChanged.connect(self.change_profile)
         self.profile_active_checkbox = QCheckBox("Aktív")
         self.profile_active_checkbox.setChecked(self.main_app.profiles[self.current_profile_name].get("active", True))
@@ -163,11 +173,6 @@ class GUI2_Widget(QWidget):
         for i, header in enumerate(headers): label = QLabel(header); label.setFont(QFont("Arial", 10, QFont.Weight.Bold)); align = Qt.AlignmentFlag.AlignLeft if i == 0 else Qt.AlignmentFlag.AlignCenter; table_layout.addWidget(label, 0, i, align)
         self.schedule_widgets = {}
         self.time_comboboxes = []
-        logic.load_profiles_from_file(self.main_app)
-        if not hasattr(self.main_app, 'profiles') or not self.main_app.profiles:
-            self.main_app.profiles = {"Alap": {"active": True, "schedule": logic.get_default_schedule()}}
-        self.current_profile_name = list(self.main_app.profiles.keys())[0]
-        self.main_app.schedule = self.main_app.profiles[self.current_profile_name]["schedule"]
         color_display_names = ["Nincs kiválasztva"] + [c[0] for c in COLORS]
         valid_color_names = [c[0] for c in COLORS]
         for i, day_hu in enumerate(DAYS):


### PR DESCRIPTION
## Summary
- keep profile selector visible by removing excess stretch
- initialize profiles before building selector to avoid startup errors
- ensure profile combo reflects current profile

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684586d7652c8327b4eafc9dbde4ad9d