### PR TITLE
Implement profile conflict check

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -294,6 +294,21 @@ class GUI2_Widget(QWidget):
         """Aktív jelölő változása."""
         active = state == Qt.CheckState.Checked.value
         self.main_app.profiles[self.current_profile_name]["active"] = active
+        if active:
+            conflicts = logic.check_profile_conflicts(self.main_app, self.current_profile_name)
+            if conflicts:
+                QMessageBox.warning(
+                    self,
+                    "Ütközés",
+                    "A(z) {} profil ütközik az alábbiakkal:\n{}".format(
+                        self.current_profile_name, "\n".join(conflicts)
+                    ),
+                )
+                self.main_app.profiles[self.current_profile_name]["active"] = False
+                self.profile_active_checkbox.blockSignals(True)
+                self.profile_active_checkbox.setChecked(False)
+                self.profile_active_checkbox.blockSignals(False)
+                return
         logic._save_profiles_to_file(self.main_app)
 
     @Slot()


### PR DESCRIPTION
## Summary
- add a conflict check to avoid overlapping active profiles
- warn user when enabling a profile that conflicts with another

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ca6523108327b7a3889fa3cddf9a