### PR TITLE
Add unsaved profile warning and layout tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.spec
+
+# IDEs and editors
+.idea/
+.vscode/
+
+# Testing
+.pytest_cache/
+
+# Executables
+LEDApp.exe
+
+# Logs
+*.log

--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -125,6 +125,61 @@ def _save_profiles_to_file(main_app):
         return False
 
 
+def check_profile_conflicts(main_app, target_name):
+    """Egyszerű ütközésvizsgálat az aktivált profilok között.
+
+    Csak az explicit on/off időket hasonlítjuk össze. A napkelte/napnyugta
+    alapú beállításokat nem ellenőrizzük, mert azok pontos ideje helyfüggő.
+
+    Args:
+        main_app: Az alkalmazás fő objektuma, amely tartalmazza a profilokat.
+        target_name: A vizsgálandó profil neve.
+
+    Returns:
+        List[str]: Napok és profilnevek, amelyek ütköznek a célprofillal.
+    """
+
+    target = main_app.profiles.get(target_name)
+    if not target:
+        return []
+
+    def parse_interval(day_data):
+        if not day_data:
+            return None
+        if day_data.get("sunrise") or day_data.get("sunset"):
+            return None
+        on_str = day_data.get("on_time")
+        off_str = day_data.get("off_time")
+        if not on_str or not off_str:
+            return None
+        try:
+            on_t = dt_time.fromisoformat(on_str)
+            off_t = dt_time.fromisoformat(off_str)
+        except ValueError:
+            return None
+        on_m = on_t.hour * 60 + on_t.minute
+        off_m = off_t.hour * 60 + off_t.minute
+        if off_m <= on_m:
+            off_m += 24 * 60
+        return on_m, off_m
+
+    conflicts = []
+    for other_name, other in main_app.profiles.items():
+        if other_name == target_name or not other.get("active", False):
+            continue
+        for day in DAYS:
+            int1 = parse_interval(target.get("schedule", {}).get(day, {}))
+            int2 = parse_interval(other.get("schedule", {}).get(day, {}))
+            if not int1 or not int2:
+                continue
+            s1, e1 = int1
+            s2, e2 = int2
+            if s1 < e2 and s2 < e1:
+                conflicts.append(f"{day} - {other_name}")
+                break
+    return conflicts
+
+
 def save_profile(gui_widget):
     """
     Elmenti az aktuális ütemezési beállításokat JSON fájlba a GUI widgetek alapján.
@@ -193,6 +248,7 @@ def save_profile(gui_widget):
         if _save_profiles_to_file(gui_widget.main_app):
             QMessageBox.information(gui_widget, "Mentés sikeres", "Az ütemezés sikeresen elmentve.")
             gui_widget.main_app.schedule = schedule_to_save
+            gui_widget.unsaved_changes = False
         else:
             QMessageBox.critical(gui_widget, "Mentési hiba", "Nem sikerült a profilok mentése.")
     except Exception as e:

--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -142,25 +142,32 @@ class GUI2_Widget(QWidget):
 
         self.current_profile_name = list(self.main_app.profiles.keys())[0]
         self.main_app.schedule = self.main_app.profiles[self.current_profile_name]["schedule"]
+        self.unsaved_changes = False
 
         # --- Profilválasztó ---
+        profile_container = QVBoxLayout()
         profile_layout = QHBoxLayout()
         profile_label = QLabel("Profil:")
         self.profile_combo = QComboBox()
-        self.profile_combo.addItems(self.main_app.profiles.keys())
+        self.profile_combo.addItems(list(self.main_app.profiles.keys()))
         self.profile_combo.setCurrentText(self.current_profile_name)
         self.profile_combo.currentTextChanged.connect(self.change_profile)
         self.profile_active_checkbox = QCheckBox("Aktív")
-        self.profile_active_checkbox.setChecked(self.main_app.profiles[self.current_profile_name].get("active", True))
+        self.profile_active_checkbox.setChecked(
+            self.main_app.profiles[self.current_profile_name].get("active", True)
+        )
         self.profile_active_checkbox.stateChanged.connect(self.toggle_profile_active)
-        add_profile_btn = QPushButton("Új profil")
-        add_profile_btn.clicked.connect(self.add_profile)
         profile_layout.addWidget(profile_label)
         profile_layout.addWidget(self.profile_combo)
         profile_layout.addWidget(self.profile_active_checkbox)
         profile_layout.addStretch(1)
-        profile_layout.addWidget(add_profile_btn)
-        main_layout.addLayout(profile_layout)
+        profile_container.addLayout(profile_layout)
+
+        add_profile_btn = QPushButton("Új profil")
+        add_profile_btn.setFixedWidth(56)
+        add_profile_btn.clicked.connect(self.add_profile)
+        profile_container.addWidget(add_profile_btn, 0, Qt.AlignmentFlag.AlignLeft)
+        main_layout.addLayout(profile_container)
 
         # --- Ütemező Táblázat (GroupBox nélkül) ---
         table_container = QWidget()
@@ -176,22 +183,29 @@ class GUI2_Widget(QWidget):
         color_display_names = ["Nincs kiválasztva"] + [c[0] for c in COLORS]
         valid_color_names = [c[0] for c in COLORS]
         for i, day_hu in enumerate(DAYS):
-            row = i + 1; day_widgets = {}; schedule_data = self.main_app.schedule.get(day_hu, {})
+            row = i + 1
+            day_widgets = {}
+            schedule_data = self.main_app.schedule.get(day_hu, {})
             day_label = QLabel(day_hu, font=QFont("Arial", 10)); table_layout.addWidget(day_label, row, 0, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             color_cb = QComboBox(); color_cb.addItems(color_display_names); saved_color = schedule_data.get("color", ""); color_cb.setCurrentIndex(color_display_names.index(saved_color) if saved_color in valid_color_names else 0)
+            color_cb.currentTextChanged.connect(self.mark_unsaved)
             table_layout.addWidget(color_cb, row, 1); day_widgets["color"] = color_cb
             time_values = [""] + [f"{h:02d}:{m:02d}" for h in range(24) for m in range(0, 60, 5)]
             on_time_cb = QComboBox(); on_time_cb.addItems(time_values); on_time_cb.setCurrentText(schedule_data.get("on_time", "")); on_time_cb.setEditable(True); on_time_cb.setFixedWidth(70)
+            on_time_cb.currentTextChanged.connect(self.mark_unsaved)
             table_layout.addWidget(on_time_cb, row, 2, Qt.AlignmentFlag.AlignCenter); day_widgets["on_time"] = on_time_cb; self.time_comboboxes.append(on_time_cb)
             off_time_cb = QComboBox(); off_time_cb.addItems(time_values); off_time_cb.setCurrentText(schedule_data.get("off_time", "")); off_time_cb.setEditable(True); off_time_cb.setFixedWidth(70)
+            off_time_cb.currentTextChanged.connect(self.mark_unsaved)
             table_layout.addWidget(off_time_cb, row, 3, Qt.AlignmentFlag.AlignCenter); day_widgets["off_time"] = off_time_cb; self.time_comboboxes.append(off_time_cb)
             sunrise_cb = QCheckBox(); sunrise_cb.setChecked(schedule_data.get("sunrise", False)); table_layout.addWidget(sunrise_cb, row, 4, Qt.AlignmentFlag.AlignCenter)
-            day_widgets["sunrise"] = sunrise_cb; sunrise_cb.stateChanged.connect(lambda state, idx=i*2, d=day_hu: self.toggle_sun_time(state, idx, d, "sunrise"))
+            day_widgets["sunrise"] = sunrise_cb; sunrise_cb.stateChanged.connect(lambda state, idx=i*2, d=day_hu: (self.mark_unsaved(), self.toggle_sun_time(state, idx, d, "sunrise")))
             sunrise_offset_entry = QLineEdit(str(schedule_data.get("sunrise_offset", 0))); sunrise_offset_entry.setFixedWidth(40); sunrise_offset_entry.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            sunrise_offset_entry.textChanged.connect(self.mark_unsaved)
             table_layout.addWidget(sunrise_offset_entry, row, 5, Qt.AlignmentFlag.AlignCenter); day_widgets["sunrise_offset"] = sunrise_offset_entry
             sunset_cb = QCheckBox(); sunset_cb.setChecked(schedule_data.get("sunset", False)); table_layout.addWidget(sunset_cb, row, 6, Qt.AlignmentFlag.AlignCenter)
-            day_widgets["sunset"] = sunset_cb; sunset_cb.stateChanged.connect(lambda state, idx=i*2+1, d=day_hu: self.toggle_sun_time(state, idx, d, "sunset"))
+            day_widgets["sunset"] = sunset_cb; sunset_cb.stateChanged.connect(lambda state, idx=i*2+1, d=day_hu: (self.mark_unsaved(), self.toggle_sun_time(state, idx, d, "sunset")))
             sunset_offset_entry = QLineEdit(str(schedule_data.get("sunset_offset", 0))); sunset_offset_entry.setFixedWidth(40); sunset_offset_entry.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            sunset_offset_entry.textChanged.connect(self.mark_unsaved)
             table_layout.addWidget(sunset_offset_entry, row, 7, Qt.AlignmentFlag.AlignCenter); day_widgets["sunset_offset"] = sunset_offset_entry
             self.schedule_widgets[day_hu] = day_widgets; self.toggle_sun_time(sunrise_cb.checkState(), i*2, day_hu, "sunrise"); self.toggle_sun_time(sunset_cb.checkState(), i*2+1, day_hu, "sunset")
         # --- Ütemező Táblázat Vége ---
@@ -252,14 +266,42 @@ class GUI2_Widget(QWidget):
         if hasattr(self, 'check_schedule_timer'): self.check_schedule_timer.stop()
         log_event("GUI2 Timers stopped.")
 
+    @Slot()
+    def mark_unsaved(self):
+        """Jelzi, hogy módosítás történt a jelenlegi profilon."""
+        self.unsaved_changes = True
+
     @Slot(str)
     def change_profile(self, name: str):
         """Profil váltása a lenyitható menüből."""
         if not name or name not in self.main_app.profiles:
             return
-        logic.save_profile(self)
+        if name == self.current_profile_name:
+            return
+        if self.unsaved_changes:
+            msg = QMessageBox(self)
+            msg.setWindowTitle("Mentés")
+            msg.setText(
+                "A módosítások nincsenek elmentve. Szeretnéd elmenteni a profil váltás előtt?"
+            )
+            yes_btn = msg.addButton("Igen", QMessageBox.AcceptRole)
+            no_btn = msg.addButton("Nem", QMessageBox.NoRole)
+            cancel_btn = msg.addButton("Mégsem", QMessageBox.RejectRole)
+            for btn in (yes_btn, no_btn, cancel_btn):
+                btn.setFixedWidth(int(btn.sizeHint().width() * 0.5))
+            msg.setDefaultButton(cancel_btn)
+            msg.exec()
+            clicked = msg.clickedButton()
+            if clicked == yes_btn:
+                logic.save_profile(self)
+            elif clicked == cancel_btn:
+                self.profile_combo.blockSignals(True)
+                self.profile_combo.setCurrentText(self.current_profile_name)
+                self.profile_combo.blockSignals(False)
+                return
         self.current_profile_name = name
         self.main_app.schedule = self.main_app.profiles[name]["schedule"]
+        self.unsaved_changes = False
         for day, widgets in self.schedule_widgets.items():
             data = self.main_app.schedule.get(day, {})
             widgets["color"].setCurrentText(data.get("color", ""))
@@ -294,6 +336,21 @@ class GUI2_Widget(QWidget):
         """Aktív jelölő változása."""
         active = state == Qt.CheckState.Checked.value
         self.main_app.profiles[self.current_profile_name]["active"] = active
+        if active:
+            conflicts = logic.check_profile_conflicts(self.main_app, self.current_profile_name)
+            if conflicts:
+                QMessageBox.warning(
+                    self,
+                    "Ütközés",
+                    "A(z) {} profil ütközik az alábbiakkal:\n{}".format(
+                        self.current_profile_name, "\n".join(conflicts)
+                    ),
+                )
+                self.main_app.profiles[self.current_profile_name]["active"] = False
+                self.profile_active_checkbox.blockSignals(True)
+                self.profile_active_checkbox.setChecked(False)
+                self.profile_active_checkbox.blockSignals(False)
+                return
         logic._save_profiles_to_file(self.main_app)
 
     @Slot()
@@ -315,6 +372,7 @@ class GUI2_Widget(QWidget):
                 widgets["sunset_offset"].setText("0")
                 self.toggle_sun_time(Qt.CheckState.Unchecked.value, list(DAYS).index(day) * 2, day, "sunrise")
                 self.toggle_sun_time(Qt.CheckState.Unchecked.value, list(DAYS).index(day) * 2 + 1, day, "sunset")
+            self.unsaved_changes = True
 
 
     @Slot(int)

--- a/gui/gui_manager.py
+++ b/gui/gui_manager.py
@@ -76,11 +76,17 @@ class GuiManager:
                  border: 1px solid #777; border-radius: 3px; background-color: #555;
                  color: #E0E0E0; selection-background-color: #0078D7;
              }
-             QComboBox::drop-down { border: none; }
-             QComboBox QAbstractItemView {
-                 background-color: #555; border: 1px solid #777;
-                 selection-background-color: #0078D7; color: #E0E0E0;
-             }
+            QComboBox::drop-down { border: none; }
+            QComboBox::down-arrow {
+                width: 0; height: 0; margin-right: 6px;
+                border-left: 5px solid transparent;
+                border-right: 5px solid transparent;
+                border-top: 7px solid #E0E0E0;
+            }
+            QComboBox QAbstractItemView {
+                background-color: #555; border: 1px solid #777;
+                selection-background-color: #0078D7; color: #E0E0E0;
+            }
              QLineEdit {
                  font-family: Arial; min-height: 1.8em; padding: 1px 3px;
                  border: 1px solid #777; border-radius: 3px;


### PR DESCRIPTION
## Summary
- add a `.gitignore` to exclude build artifacts
- redesign profile selector layout
- track unsaved scheduler edits and confirm saving when switching profiles
- store unsaved flag after saving profiles
- shrink profile add button and translate unsaved confirmation options

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846ca6523108327b7a3889fa3cddf9a