### PR TITLE
Add brightness slider with persistent setting

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -27,6 +27,7 @@ DEFAULT_SETTINGS = {
     "last_device_address": None,
     "last_device_name": None, # Hozzáadva a név is
     "auto_connect_on_startup": True, # Új beállítás: automatikus csatlakozás induláskor
+    "brightness_level": 80,  # Fényerő százalékos értéke (0-100)
 }
 
 def _get_settings_path():


### PR DESCRIPTION
## Summary
- persist brightness level in settings
- add vertical brightness slider next to profile controls
- send brightness command `7e0001ZZ00000000ef` when slider changes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684872bbbcd08327b1b20530e803b75f