### PR TITLE
Fix Windows startup registry handling

### DIFF
--- a/core/registry_utils.py
+++ b/core/registry_utils.py
@@ -20,7 +20,10 @@ except ImportError:
 
 APP_NAME = "LEDApp" # Az alkalmazás neve a registryben
 # Fontos: A sys.executable adja meg a futtatható fájl (.exe) elérési útját PyInstaller után
-APP_PATH = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0] # Ha scriptként fut, akkor a .py fájl
+# A futtatható fájl abszolút elérési útja.
+APP_PATH = os.path.abspath(
+    sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
+)  # Ha scriptként fut, akkor a .py fájl
 
 # Az indítópult registry kulcsa az aktuális felhasználóhoz
 RUN_KEY_PATH = r"Software\Microsoft\Windows\CurrentVersion\Run"
@@ -32,12 +35,12 @@ def _get_startup_command():
     return f'"{APP_PATH}" --tray' # Korábban --startup volt itt, de a --tray logikusabb
 
 def add_to_startup():
-    """ Hozzáadja az alkalmazást az indítópulthoz a registryben. """
+    """Hozzáadja az alkalmazást az indítópulthoz a registryben."""
     try:
-        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_SET_VALUE)
-        command = _get_startup_command()
-        winreg.SetValueEx(key, APP_NAME, 0, winreg.REG_SZ, command)
-        winreg.CloseKey(key)
+        # Ha a kulcs hiányzik, létrehozzuk
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH) as key:
+            command = _get_startup_command()
+            winreg.SetValueEx(key, APP_NAME, 0, winreg.REG_SZ, command)
         log_event(f"Alkalmazás hozzáadva az indítópulthoz: '{command}'")
         return True
     except OSError as e:
@@ -48,16 +51,15 @@ def add_to_startup():
         return False
 
 def remove_from_startup():
-    """ Eltávolítja az alkalmazást az indítópultból a registryben. """
+    """Eltávolítja az alkalmazást az indítópultból a registryben."""
     try:
-        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_SET_VALUE)
-        winreg.DeleteValue(key, APP_NAME)
-        winreg.CloseKey(key)
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, APP_NAME)
         log_event("Alkalmazás eltávolítva az indítópultból.")
         return True
     except FileNotFoundError:
         log_event("Alkalmazás nem volt az indítópultban (nem található a kulcs).")
-        return True # Nem hiba, ha már nincs ott
+        return True  # Nem hiba, ha már nincs ott
     except OSError as e:
         log_event(f"Hiba az indítópultból való eltávolítás során: {e}")
         return False
@@ -68,9 +70,8 @@ def remove_from_startup():
 def is_in_startup():
     """ Ellenőrzi, hogy az alkalmazás szerepel-e az indítópultban. """
     try:
-        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_READ)
-        winreg.QueryValueEx(key, APP_NAME)
-        winreg.CloseKey(key)
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY_PATH, 0, winreg.KEY_READ) as key:
+            winreg.QueryValueEx(key, APP_NAME)
         return True
     except FileNotFoundError:
         return False


### PR DESCRIPTION
## Summary
- ensure absolute path is stored in registry
- use context managers for registry operations
- create registry key if missing

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68487fe44b0c832790ac32ce59132b89