### PR TITLE
Add smaller profile buttons

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -165,16 +165,19 @@ class GUI2_Widget(QWidget):
         profile_container.addLayout(profile_layout)
 
         add_profile_btn = QPushButton("Új profil")
+        add_profile_btn.setObjectName("addProfileButton")
         add_profile_btn.setFixedSize(80, 25)
         add_profile_btn.clicked.connect(self.add_profile)
         profile_container.addWidget(add_profile_btn, 0, Qt.AlignmentFlag.AlignLeft)
 
         delete_profile_btn = QPushButton("Profil törlése")
+        delete_profile_btn.setObjectName("deleteProfileButton")
         delete_profile_btn.setFixedSize(80, 25)
         delete_profile_btn.clicked.connect(self.delete_profile)
         profile_container.addWidget(delete_profile_btn, 0, Qt.AlignmentFlag.AlignLeft)
 
         custom_color_btn = QPushButton("Egyedi szín...")
+        custom_color_btn.setObjectName("customColorButton")
         custom_color_btn.setFixedSize(80, 25)
         custom_color_btn.clicked.connect(self.controls_widget.pick_custom_color)
         profile_container.addWidget(custom_color_btn, 0, Qt.AlignmentFlag.AlignLeft)

--- a/gui/gui_manager.py
+++ b/gui/gui_manager.py
@@ -61,6 +61,12 @@ class GuiManager:
             QPushButton#powerOnButton { background-color: #308030; }
             QPushButton#powerOnButton:hover { background-color: #409040; }
             QPushButton#powerOnButton:pressed { background-color: #207020; }
+            QPushButton#addProfileButton,
+            QPushButton#deleteProfileButton,
+            QPushButton#customColorButton {
+                min-width: 5em;
+                min-height: 1.6em;
+            }
             QListWidget {
                 font-family: Arial; font-size: 11pt; background-color: #444;
                 color: #E0E0E0; border: 1px solid #777;


### PR DESCRIPTION
## Summary
- provide object names for the profile buttons
- adjust stylesheet so these buttons have smaller min size

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684884a623c4832790288b2852f8f12a