### PR TITLE
Notify user if Bluetooth is disabled

### DIFF
--- a/tests/test_ble_controller.py
+++ b/tests/test_ble_controller.py
@@ -1,0 +1,39 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _ensure_dummy_bleak(monkeypatch):
+    """Create a dummy bleak module if bleak is missing."""
+    if "bleak" not in sys.modules:
+        dummy = types.ModuleType("bleak")
+        dummy.BleakError = type("BleakError", (Exception,), {})
+        dummy.BleakClient = object
+        dummy.BleakScanner = object
+        monkeypatch.setitem(sys.modules, "bleak", dummy)
+
+
+import importlib
+
+
+def setup_module(module):
+    # ensure bleak dummy present and reload controller
+    from _pytest.monkeypatch import MonkeyPatch
+    mp = MonkeyPatch()
+    _ensure_dummy_bleak(mp)
+    module.bc = importlib.import_module("core.ble_controller")
+
+
+def test_is_bluetooth_off_error_by_winerror():
+    controller = bc.BLEController()
+    err = OSError("Das Gerät kann nicht verwendet werden")
+    err.winerror = -2147020577
+    assert controller._is_bluetooth_off_error(err)
+
+
+def test_is_bluetooth_off_error_by_message():
+    controller = bc.BLEController()
+    err = bc.BleakError("Bluetooth adapter is off") if hasattr(bc, "BleakError") else Exception("Bluetooth adapter is off")
+    assert controller._is_bluetooth_off_error(err)

--- a/tests/test_schedule_logic.py
+++ b/tests/test_schedule_logic.py
@@ -20,6 +20,14 @@ def setup_pyside(monkeypatch):
     monkeypatch.setitem(sys.modules, "PySide6", pyside)
     monkeypatch.setitem(sys.modules, "PySide6.QtWidgets", widgets)
     monkeypatch.setitem(sys.modules, "PySide6.QtCore", core)
+    # minimal pytz substitute
+    tz = types.SimpleNamespace(zone="UTC")
+    pytz_dummy = types.SimpleNamespace(
+        timezone=lambda x: types.SimpleNamespace(zone=x),
+        UnknownTimeZoneError=Exception,
+        utc=tz,
+    )
+    monkeypatch.setitem(sys.modules, "pytz", pytz_dummy)
     monkeypatch.setitem(
         sys.modules,
         "core.sun_logic",


### PR DESCRIPTION
## Summary
- detect Bluetooth-off exceptions in `BLEController.scan`
- add `_is_bluetooth_off_error` helper
- provide dummy `pytz` in schedule tests
- add tests for `_is_bluetooth_off_error`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea7c96f508327aa8f33c2389be8f5