### PR TITLE
Improve IP geolocation fallback

### DIFF
--- a/core/location_utils.py
+++ b/core/location_utils.py
@@ -54,12 +54,36 @@ def _fetch_coords_ipwhois():
     return data["latitude"], data["longitude"]
 
 
+def _fetch_coords_ipapico():
+    """Lekérdezi a koordinátákat az ipapi.co szolgáltatásból."""
+    headers = {"User-Agent": "LEDApp/1.0"}
+    response = requests.get("https://ipapi.co/json/", timeout=5, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    if "latitude" not in data or "longitude" not in data:
+        raise RuntimeError("latitude/longitude missing")
+    return data["latitude"], data["longitude"]
+
+
+def _fetch_coords_geolocationdb():
+    """Lekérdezi a koordinátákat a geolocation-db.com szolgáltatásból."""
+    headers = {"User-Agent": "LEDApp/1.0"}
+    response = requests.get("https://geolocation-db.com/json/", timeout=5, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    if "latitude" not in data or "longitude" not in data:
+        raise RuntimeError("latitude/longitude missing")
+    return float(data["latitude"]), float(data["longitude"])
+
+
 def get_coordinates():
     """Megpróbálja lekérni a koordinátákat több forrásból."""
     for fetcher, name in (
         (_fetch_coords_ipapi, "ip-api.com"),
         (_fetch_coords_ipinfo, "ipinfo.io"),
         (_fetch_coords_ipwhois, "ipwho.is"),
+        (_fetch_coords_ipapico, "ipapi.co"),
+        (_fetch_coords_geolocationdb, "geolocation-db.com"),
     ):
         try:
             log_event(f"Koordináták lekérése ({name})...")

--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QMessageBox
 
 # Importáljuk a szükséges konfigurációs és backend/core elemeket
 from config import COLORS, DAYS, CONFIG_FILE, PROFILES_FILE
-from core.sun_logic import DAYS_HU
+from core.sun_logic import DAYS_HU, get_local_sun_info as _core_get_local_sun_info
 from core.location_utils import get_sun_times  # noqa: F401
 
 # --- Időzóna Definíció ---
@@ -34,6 +34,11 @@ except Exception as e:
     LOCAL_TZ = pytz.utc
 
 # --- Logika Függvények ---
+
+
+def get_local_sun_info():
+    """Wrapper around core.sun_logic.get_local_sun_info."""
+    return _core_get_local_sun_info()
 
 
 def get_default_schedule():
@@ -349,7 +354,6 @@ def check_profiles(gui_widget):
                     continue
 
                 intervals.append((on_time_dt, off_time_dt, target_color_hex))
-
 
         if intervals:
             intervals.sort(key=lambda x: x[0])


### PR DESCRIPTION
## Summary
- add two additional geolocation providers
- try them when determining coordinates
- expose get_local_sun_info in GUI logic

## Testing
- `black gui/gui2_schedule_logic.py core/location_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eab388fb88327a21ba698d86b4c79