### PR TITLE
Add timeline widget for schedule overview

### DIFF
--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -185,6 +185,75 @@ def check_profile_conflicts(main_app, target_name):
     return conflicts
 
 
+def get_profile_day_intervals(main_app, profile_name):
+    """Return schedule intervals in minutes for drawing a timeline."""
+
+    profile = main_app.profiles.get(profile_name)
+    if not profile:
+        return {}
+
+    result = {}
+    schedule = profile.get("schedule", {})
+    today = datetime.now(LOCAL_TZ).date()
+    today_idx = today.weekday()
+
+    for idx, day in enumerate(DAYS):
+        data = schedule.get(day, {})
+        intervals = []
+        ref_date = today + timedelta(days=(idx - today_idx) % 7)
+        on_dt, off_dt = None, None
+
+        if data.get("sunrise"):
+            sr, _ = get_sun_times(main_app.latitude, main_app.longitude, datetime.combine(ref_date, dt_time()))
+            if sr:
+                try:
+                    on_dt = sr + timedelta(minutes=int(data.get("sunrise_offset", 0)))
+                except Exception:
+                    on_dt = sr
+        else:
+            on_str = data.get("on_time")
+            if on_str:
+                try:
+                    on_dt = LOCAL_TZ.localize(datetime.combine(ref_date, dt_time.fromisoformat(on_str)))
+                except Exception:
+                    pass
+
+        if data.get("sunset"):
+            _, ss = get_sun_times(main_app.latitude, main_app.longitude, datetime.combine(ref_date, dt_time()))
+            if ss:
+                try:
+                    off_dt = ss + timedelta(minutes=int(data.get("sunset_offset", 0)))
+                except Exception:
+                    off_dt = ss
+        else:
+            off_str = data.get("off_time")
+            if off_str:
+                try:
+                    off_dt = LOCAL_TZ.localize(datetime.combine(ref_date, dt_time.fromisoformat(off_str)))
+                except Exception:
+                    pass
+
+        if on_dt and off_dt:
+            if off_dt <= on_dt:
+                off_dt += timedelta(days=1)
+
+            start_min = on_dt.hour * 60 + on_dt.minute
+            end_min = off_dt.hour * 60 + off_dt.minute
+
+            color_name = data.get("color", "")
+            color_hex = next((c[1] for c in COLORS if c[0] == color_name), "#ffffff")
+
+            if end_min > 24 * 60:
+                intervals.append((start_min, 24 * 60, color_hex))
+                intervals.append((0, end_min - 24 * 60, color_hex))
+            else:
+                intervals.append((start_min, end_min, color_hex))
+
+        result[day] = intervals
+
+    return result
+
+
 def save_profile(gui_widget):
     """
     Elmenti az aktuális ütemezési beállításokat JSON fájlba a GUI widgetek alapján.

--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -41,6 +41,7 @@ try:
     from gui import gui2_schedule_logic as logic
     from gui.gui2_controls_pyside import GUI2_ControlsWidget
     from gui.custom_color_dialog import CustomColorDialog
+    from gui.timeline_widget import TimelineWidget
 
     logic.LOCAL_TZ = LOCAL_TZ
     log_event("GUI2Schedule: Szükséges modulok sikeresen importálva.")
@@ -274,6 +275,10 @@ class GUI2_Widget(QWidget):
 
         main_layout.addLayout(profile_container)
 
+        # Timeline visualization
+        self.timeline_widget = TimelineWidget(self.main_app, self.current_profile_name)
+        main_layout.addWidget(self.timeline_widget)
+
         # --- Ütemező Táblázat (GroupBox nélkül) ---
         table_container = QWidget()
         table_layout = QGridLayout(table_container)
@@ -395,7 +400,7 @@ class GUI2_Widget(QWidget):
         reset_button.clicked.connect(self.reset_schedule_gui)
         schedule_action_layout.addWidget(reset_button)  # Gombok jobb oldalon
         save_button = QPushButton("Mentés")
-        save_button.clicked.connect(lambda: logic.save_profile(self))
+        save_button.clicked.connect(self.save_profile_slot)
         schedule_action_layout.addWidget(save_button)
 
         main_layout.addLayout(schedule_action_layout)  # Hozzáadás a fő layout-hoz
@@ -434,12 +439,23 @@ class GUI2_Widget(QWidget):
             self.update_time_timer.stop()
         if hasattr(self, "check_schedule_timer"):
             self.check_schedule_timer.stop()
+        if hasattr(self, "timeline_widget") and hasattr(self.timeline_widget, "timer"):
+            self.timeline_widget.timer.stop()
         log_event("GUI2 Timers stopped.")
 
     @Slot()
     def mark_unsaved(self):
         """Jelzi, hogy módosítás történt a jelenlegi profilon."""
         self.unsaved_changes = self.is_schedule_modified()
+        if hasattr(self, "timeline_widget"):
+            self.timeline_widget.refresh(self.current_profile_name)
+
+    @Slot()
+    def save_profile_slot(self):
+        """Saves profile then refreshes the timeline widget."""
+        logic.save_profile(self)
+        if hasattr(self, "timeline_widget"):
+            self.timeline_widget.refresh(self.current_profile_name)
 
     def is_schedule_modified(self):
         """Összehasonlítja a jelenlegi beállításokat a mentett profillal."""
@@ -518,6 +534,8 @@ class GUI2_Widget(QWidget):
         self.profile_active_checkbox.blockSignals(True)
         self.profile_active_checkbox.setChecked(self.main_app.profiles[name].get("active", True))
         self.profile_active_checkbox.blockSignals(False)
+        if hasattr(self, "timeline_widget"):
+            self.timeline_widget.refresh(self.current_profile_name)
 
     @Slot()
     def add_profile(self):

--- a/gui/timeline_widget.py
+++ b/gui/timeline_widget.py
@@ -1,0 +1,68 @@
+from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import QTimer, QRectF
+from PySide6.QtGui import QColor, QPainter, QPen
+
+from datetime import datetime
+
+from config import DAYS
+from gui import gui2_schedule_logic as logic
+
+
+class TimelineWidget(QWidget):
+    """Simple timeline visualization of daily schedule intervals."""
+
+    def __init__(self, main_app, profile_name=None, parent=None):
+        super().__init__(parent)
+        self.main_app = main_app
+        self.profile_name = profile_name
+        self.intervals = {}
+        self.setMinimumHeight(160)
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update)
+        self.timer.start(60_000)  # refresh every minute
+
+        self.refresh(profile_name)
+
+    def refresh(self, profile_name=None):
+        """Reload intervals for the given profile and repaint."""
+        if profile_name is not None:
+            self.profile_name = profile_name
+        if not self.profile_name:
+            self.intervals = {}
+        else:
+            self.intervals = logic.get_profile_day_intervals(self.main_app, self.profile_name)
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        left_margin = 60
+        top_margin = 5
+        row_height = max(20, (self.height() - top_margin * 2) // len(DAYS))
+        width = self.width() - left_margin - 10
+
+        painter.fillRect(self.rect(), self.palette().window())
+        painter.setPen(QPen(QColor("gray")))
+
+        # draw hour grid
+        for h in range(25):
+            x = left_margin + width * h / 24
+            painter.drawLine(int(x), top_margin, int(x), top_margin + row_height * len(DAYS))
+        for i, day in enumerate(DAYS):
+            y = top_margin + i * row_height
+            painter.drawText(5, y + row_height * 0.7, day)
+            painter.drawLine(left_margin, y, left_margin + width, y)
+            for start, end, color in self.intervals.get(day, []):
+                x1 = left_margin + width * start / (24 * 60)
+                x2 = left_margin + width * end / (24 * 60)
+                rect = QRectF(x1, y + 2, x2 - x1, row_height - 4)
+                painter.fillRect(rect, QColor(color))
+
+        # current time indicator
+        now = datetime.now(logic.LOCAL_TZ)
+        total_min = now.hour * 60 + now.minute
+        x = left_margin + width * total_min / (24 * 60)
+        pen = QPen(QColor("red"))
+        pen.setWidth(2)
+        painter.setPen(pen)
+        painter.drawLine(int(x), top_margin, int(x), top_margin + row_height * len(DAYS))


### PR DESCRIPTION
## Summary
- visualize daily schedule intervals via new `TimelineWidget`
- compute profile day intervals in schedule logic
- embed timeline widget in schedule GUI
- refresh timeline on edits and saves

## Testing
- `black gui/timeline_widget.py gui/gui2_schedule_logic.py gui/gui2_schedule_pyside.py -q`
- `flake8 gui/timeline_widget.py gui/gui2_schedule_logic.py gui/gui2_schedule_pyside.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ec35b7b708327bc57f9497b6030af