### PR TITLE
Show schedules of all profiles in one timeline

### DIFF
--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -254,6 +254,16 @@ def get_profile_day_intervals(main_app, profile_name):
     return result
 
 
+def get_all_profiles_day_intervals(main_app):
+    """Return combined schedule intervals for all profiles."""
+    combined = {day: [] for day in DAYS}
+    for name in getattr(main_app, "profiles", {}):
+        prof_intervals = get_profile_day_intervals(main_app, name)
+        for day, intervals in prof_intervals.items():
+            combined[day].extend(intervals)
+    return combined
+
+
 def save_profile(gui_widget):
     """
     Elmenti az aktuális ütemezési beállításokat JSON fájlba a GUI widgetek alapján.

--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -275,8 +275,8 @@ class GUI2_Widget(QWidget):
 
         main_layout.addLayout(profile_container)
 
-        # Timeline visualization
-        self.timeline_widget = TimelineWidget(self.main_app, self.current_profile_name)
+        # Timeline visualization (shows all profiles)
+        self.timeline_widget = TimelineWidget(self.main_app)
         main_layout.addWidget(self.timeline_widget)
 
         # --- Ütemező Táblázat (GroupBox nélkül) ---
@@ -448,14 +448,14 @@ class GUI2_Widget(QWidget):
         """Jelzi, hogy módosítás történt a jelenlegi profilon."""
         self.unsaved_changes = self.is_schedule_modified()
         if hasattr(self, "timeline_widget"):
-            self.timeline_widget.refresh(self.current_profile_name)
+            self.timeline_widget.refresh()
 
     @Slot()
     def save_profile_slot(self):
         """Saves profile then refreshes the timeline widget."""
         logic.save_profile(self)
         if hasattr(self, "timeline_widget"):
-            self.timeline_widget.refresh(self.current_profile_name)
+            self.timeline_widget.refresh()
 
     def is_schedule_modified(self):
         """Összehasonlítja a jelenlegi beállításokat a mentett profillal."""
@@ -535,7 +535,7 @@ class GUI2_Widget(QWidget):
         self.profile_active_checkbox.setChecked(self.main_app.profiles[name].get("active", True))
         self.profile_active_checkbox.blockSignals(False)
         if hasattr(self, "timeline_widget"):
-            self.timeline_widget.refresh(self.current_profile_name)
+            self.timeline_widget.refresh()
 
     @Slot()
     def add_profile(self):

--- a/gui/timeline_widget.py
+++ b/gui/timeline_widget.py
@@ -9,12 +9,11 @@ from gui import gui2_schedule_logic as logic
 
 
 class TimelineWidget(QWidget):
-    """Simple timeline visualization of daily schedule intervals."""
+    """Timeline visualization showing schedules from all profiles."""
 
-    def __init__(self, main_app, profile_name=None, parent=None):
+    def __init__(self, main_app, parent=None):
         super().__init__(parent)
         self.main_app = main_app
-        self.profile_name = profile_name
         self.intervals = {}
         self.setMinimumHeight(160)
 
@@ -22,23 +21,19 @@ class TimelineWidget(QWidget):
         self.timer.timeout.connect(self.update)
         self.timer.start(60_000)  # refresh every minute
 
-        self.refresh(profile_name)
+        self.refresh()
 
-    def refresh(self, profile_name=None):
-        """Reload intervals for the given profile and repaint."""
-        if profile_name is not None:
-            self.profile_name = profile_name
-        if not self.profile_name:
-            self.intervals = {}
-        else:
-            self.intervals = logic.get_profile_day_intervals(self.main_app, self.profile_name)
+    def refresh(self):
+        """Reload intervals for all profiles and repaint."""
+        self.intervals = logic.get_all_profiles_day_intervals(self.main_app)
         self.update()
 
     def paintEvent(self, event):
         painter = QPainter(self)
         left_margin = 60
         top_margin = 5
-        row_height = max(20, (self.height() - top_margin * 2) // len(DAYS))
+        bottom_margin = 20
+        row_height = max(20, (self.height() - top_margin - bottom_margin) // len(DAYS))
         width = self.width() - left_margin - 10
 
         painter.fillRect(self.rect(), self.palette().window())
@@ -48,6 +43,8 @@ class TimelineWidget(QWidget):
         for h in range(25):
             x = left_margin + width * h / 24
             painter.drawLine(int(x), top_margin, int(x), top_margin + row_height * len(DAYS))
+            if h % 2 == 0:
+                painter.drawText(int(x) - 10, top_margin + row_height * len(DAYS) + 15, f"{h:02d}")
         for i, day in enumerate(DAYS):
             y = top_margin + i * row_height
             painter.drawText(5, y + row_height * 0.7, day)


### PR DESCRIPTION
## Summary
- combine intervals from every profile
- visualize all profiles at once in the timeline widget and label hours at the bottom
- update schedule GUI to refresh aggregated timeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec7ae96b483279a9bbbd61e9e3b1f