### PR TITLE
Improve GUI2 usability on small screens

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QSizePolicy,
     QMessageBox,
     QInputDialog,  # QGroupBox eltávolítva
+    QScrollArea,
 )
 from PySide6.QtCore import Qt, QTimer, Slot
 from PySide6.QtGui import QFont
@@ -133,8 +134,17 @@ class GUI2_Widget(QWidget):
         self.setObjectName("GUI2_Widget_Instance")
         self.main_app = main_app
 
+        # --- Scrollable content area ---
+        outer_layout = QVBoxLayout(self)
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        outer_layout.addWidget(scroll_area)
+
+        scroll_content = QWidget()
+        scroll_area.setWidget(scroll_content)
+
         # --- Fő vertikális layout ---
-        main_layout = QVBoxLayout(self)
+        main_layout = QVBoxLayout(scroll_content)
         main_layout.setContentsMargins(10, 5, 10, 10)  # Kisebb felső margó
         main_layout.setSpacing(5)  # Kisebb alap térköz
 

--- a/gui/gui_manager.py
+++ b/gui/gui_manager.py
@@ -198,7 +198,8 @@ class GuiManager:
 
         self.clear_window_content()  # Ez most GUI1-et töröl, nem állít le loopot
         self.app.setWindowTitle(f"LED-Irányító 2000 - {self.app.selected_device[0]}")
-        self.app.resize(1080, 864)
+        # Reduced default size so the window fits on smaller screens
+        self.app.resize(800, 700)
 
         widget = GUI2_Widget(self.app)  # Fő app példány átadása
         self.main_layout.addWidget(widget)


### PR DESCRIPTION
## Summary
- shrink GUI2 window to 800x700
- wrap GUI2 layout in a `QScrollArea` for vertical scrolling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eca4b46208327a97e4ae894bbeb1c