### PR TITLE
Add spacing around schedule timeline

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -287,7 +287,9 @@ class GUI2_Widget(QWidget):
 
         # Timeline visualization (shows all profiles)
         self.timeline_widget = TimelineWidget(self.main_app)
+        main_layout.addSpacing(15)
         main_layout.addWidget(self.timeline_widget)
+        main_layout.addSpacing(15)
 
         # --- Ütemező Táblázat (GroupBox nélkül) ---
         table_container = QWidget()


### PR DESCRIPTION
## Summary
- add vertical spacing around the schedule timeline widget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecd542a888327b0b418a05a6628ce