### PR TITLE
Update layout and spacing

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -283,7 +283,17 @@ class GUI2_Widget(QWidget):
         add_profile_btn.setObjectName("addProfileButton")
         add_profile_btn.setFixedSize(80, 25)
         add_profile_btn.clicked.connect(self.add_profile)
-        profile_container.addWidget(add_profile_btn, 0, Qt.AlignmentFlag.AlignLeft)
+
+        custom_color_btn = QPushButton("Egyedi szín")
+        custom_color_btn.setObjectName("customColorButton")
+        custom_color_btn.setFixedSize(100, 25)
+        custom_color_btn.clicked.connect(self.open_custom_colors)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(add_profile_btn)
+        btn_layout.addWidget(custom_color_btn)
+        btn_layout.addStretch(1)
+        profile_container.addLayout(btn_layout)
 
         delete_profile_btn = QPushButton("Profil törlése")
         delete_profile_btn.setObjectName("deleteProfileButton")
@@ -291,17 +301,11 @@ class GUI2_Widget(QWidget):
         delete_profile_btn.clicked.connect(self.delete_profile)
         profile_container.addWidget(delete_profile_btn, 0, Qt.AlignmentFlag.AlignLeft)
 
-        custom_color_btn = QPushButton("Egyedi szín")
-        custom_color_btn.setObjectName("customColorButton")
-        custom_color_btn.setFixedSize(100, 25)
-        custom_color_btn.clicked.connect(self.open_custom_colors)
-        profile_container.addWidget(custom_color_btn, 0, Qt.AlignmentFlag.AlignLeft)
-
         main_layout.addLayout(profile_container)
 
         # Timeline visualization (shows all profiles)
         self.timeline_widget = TimelineWidget(self.main_app)
-        main_layout.addSpacing(15)
+        main_layout.addSpacing(25)
         main_layout.addWidget(self.timeline_widget)
         main_layout.addSpacing(15)
 

--- a/tests/test_ble_controller.py
+++ b/tests/test_ble_controller.py
@@ -15,25 +15,30 @@ def _ensure_dummy_bleak(monkeypatch):
         monkeypatch.setitem(sys.modules, "bleak", dummy)
 
 
-import importlib
+import importlib  # noqa: E402
 
 
 def setup_module(module):
     # ensure bleak dummy present and reload controller
     from _pytest.monkeypatch import MonkeyPatch
+
     mp = MonkeyPatch()
     _ensure_dummy_bleak(mp)
     module.bc = importlib.import_module("core.ble_controller")
 
 
 def test_is_bluetooth_off_error_by_winerror():
-    controller = bc.BLEController()
+    controller = bc.BLEController()  # noqa: F821
     err = OSError("Das Gerät kann nicht verwendet werden")
     err.winerror = -2147020577
     assert controller._is_bluetooth_off_error(err)
 
 
 def test_is_bluetooth_off_error_by_message():
-    controller = bc.BLEController()
-    err = bc.BleakError("Bluetooth adapter is off") if hasattr(bc, "BleakError") else Exception("Bluetooth adapter is off")
+    controller = bc.BLEController()  # noqa: F821
+    err = (
+        bc.BleakError("Bluetooth adapter is off")  # noqa: F821
+        if hasattr(bc, "BleakError")  # noqa: F821
+        else Exception("Bluetooth adapter is off")
+    )
     assert controller._is_bluetooth_off_error(err)


### PR DESCRIPTION
## Summary
- move "Egyedi szín" button next to "Új profil" in profile section
- add extra spacing before timeline widget
- silence flake8 warnings in BLE controller tests

## Testing
- `flake8`
- `black --check gui/gui2_schedule_pyside.py tests/test_ble_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecfc9c68c832787e70904e51701c9