### PR TITLE
Make time fields gray/disabled on sunrise/sunset

### DIFF
--- a/gui/gui2_schedule_pyside.py
+++ b/gui/gui2_schedule_pyside.py
@@ -725,9 +725,11 @@ class GUI2_Widget(QWidget):
 
         if is_checked:
             time_combo.setEnabled(False)
+            time_combo.setStyleSheet("color: gray; background-color: lightgray;")
             offset_entry.setEnabled(True)
         else:
             time_combo.setEnabled(True)
+            time_combo.setStyleSheet("")
             offset_entry.setEnabled(False)
 
     @Slot()


### PR DESCRIPTION
## Summary
- darken & disable time fields when sunrise/sunset is checked

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed04e02e483278b622fd48923409a