### PR TITLE
Adjust GUI2 width

### DIFF
--- a/gui/gui_manager.py
+++ b/gui/gui_manager.py
@@ -198,8 +198,8 @@ class GuiManager:
 
         self.clear_window_content()  # Ez most GUI1-et töröl, nem állít le loopot
         self.app.setWindowTitle(f"LED-Irányító 2000 - {self.app.selected_device[0]}")
-        # Increased default width so the schedule view fits without a horizontal scrollbar
-        self.app.resize(1100, 700)
+        # Default width adjusted so the schedule view still fits comfortably
+        self.app.resize(950, 700)
 
         widget = GUI2_Widget(self.app)  # Fő app példány átadása
         self.main_layout.addWidget(widget)


### PR DESCRIPTION
## Summary
- shrink GUI2 default window width so schedule still fits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed1f031248327bcc4e4ee3e1246b8