### PR TITLE
Add cross-midnight schedule test and logic fix

### DIFF
--- a/gui/gui2_schedule_logic.py
+++ b/gui/gui2_schedule_logic.py
@@ -435,16 +435,8 @@ def check_profiles(gui_widget):
                 intervals.append((on_time_dt, off_time_dt, target_color_hex))
 
         if intervals:
-            intervals.sort(key=lambda x: x[0])
-            first_start = intervals[0][0]
-            last_end = max(i[1] for i in intervals)
-            cycle_duration = last_end - first_start
-            if cycle_duration.total_seconds() <= 0:
-                cycle_duration = timedelta(days=1)
-            rel_now = (now_local - first_start) % cycle_duration
-            point_time = first_start + rel_now
             for start, end, hex_color in intervals:
-                if start <= point_time < end:
+                if start <= now_local < end:
                     desired_hex = hex_color
                     break
 


### PR DESCRIPTION
## Summary
- add a test for `check_profiles` handling a 22:00‑02:00 schedule
- fix `check_profiles` to choose colors based on actual time range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed38e6d348327b6f0babc154aeb2d